### PR TITLE
WEBDEV-7037 Add `collection_layout` metadata field

### DIFF
--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -127,6 +127,12 @@ export class Metadata {
       : undefined;
   }
 
+  @Memoize() get collection_layout(): StringField | undefined {
+    return this.rawMetadata?.collection_layout
+      ? new StringField(this.rawMetadata.collection_layout)
+      : undefined;
+  }
+
   @Memoize() get date(): DateField | undefined {
     return this.rawMetadata?.date
       ? new DateField(this.rawMetadata.date)


### PR DESCRIPTION
Adds a `collection_layout` field to metadata, for use in the new custom collections.