### PR TITLE
Update CI to fix codecov and use more recent node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v3
       with:
-        node-version: 15.x
+        node-version: 18.x
 
     - name: Install dependencies
       run: npm install
@@ -22,5 +22,6 @@ jobs:
     - name: Run tests
       run: npm run test
 
-    - name: Upload CodeCov
-      run: npm run codecov
+    - uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Updates CI config to replace the deprecated codecov uploader package with the newer codecov GH action. Also upgrades the checkout and setup-node dependencies and bumps the version of node being used.