### PR TITLE
WEBDEV-7436 Add reviewer_itemname to review class

### DIFF
--- a/src/models/review.ts
+++ b/src/models/review.ts
@@ -17,6 +17,10 @@ export class Review {
     return this.rawValue.reviewer;
   }
 
+  get reviewer_itemname(): string | undefined {
+    return this.rawValue.reviewer_itemname;
+  }
+
   @Memoize() get reviewdate(): Date | undefined {
     return this.rawValue.reviewdate != null
       ? DateParser.shared.parseValue(this.rawValue.reviewdate)


### PR DESCRIPTION
Adds `reviewer_itemname` to the `Review` class to match production and support new functionality in `iaux-reviews`.