### PR TITLE
Remove credentials: 'omit' override from DefaultMetadataBackend

### DIFF
--- a/src/backend/default-metadata-backend.ts
+++ b/src/backend/default-metadata-backend.ts
@@ -53,13 +53,7 @@ export class DefaultMetadataBackend implements MetadataBackendInterface {
   ): Promise<Result<any, MetadataServiceError>> {
     const path = keypath ? `/${keypath}` : '';
     const url = `https://${this.baseUrl}/metadata/${identifier}${path}`;
-    // the metadata endpoint doesn't currently support credentialed requests
-    // so don't include credentials until that is fixed
-    return this.fetchUrl(url, {
-      requestOptions: {
-        credentials: 'omit',
-      },
-    });
+    return this.fetchUrl(url);
   }
 
   /**

--- a/test/default-metadata-backend.test.ts
+++ b/test/default-metadata-backend.test.ts
@@ -79,7 +79,7 @@ describe('DefaultMetadataBackend', () => {
     window.fetch = fetchBackup;
   });
 
-  it('does not credentials for metadata endpoint', async () => {
+  it('credentials for metadata endpoint', async () => {
     const fetchBackup = window.fetch;
     let urlCalled: RequestInfo | URL;
     let urlConfig: RequestInit | undefined;
@@ -98,7 +98,7 @@ describe('DefaultMetadataBackend', () => {
       includeCredentials: true,
     });
     await backend.fetchMetadata('foo');
-    expect(urlConfig?.credentials).to.equal('omit');
+    expect(urlConfig?.credentials).to.equal('include');
     window.fetch = fetchBackup;
   });
 });


### PR DESCRIPTION
The note "the metadata endpoint doesn't currently support credentialed requests so don't include credentials until that is fixed" no longer applies, the fix is to remove the override, allowing default fetchOption logic to govern credential inclusion (see default-metadata-backend.ts lines 84-68 / 78-80)