### PR TITLE
1.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/metadata-service",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/metadata-service",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/field-parsers": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/metadata-service",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A service for fetching metadata about items in the Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bumps version to 1.0.6, releasing the credentials-on-fetchMetadata change merged in #14.

## Test plan

- [ ] `npm test` — all tests pass.
- [ ] `npm publish` cleanly after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)